### PR TITLE
Engine: limit multiple ship mode msg detection

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -861,8 +861,9 @@ void Engine::Step(bool isActive)
 						std::string message = "The " + target->Name() + " was detected as a \"" +
 									target->VariantName() + "\" model ship";
 
-						Messages::Add(message, Messages::Importance::High);
-						player.DiscoverShipModel(*target.get());
+						// if model was instered, prints the status msg
+						if(player.DiscoverShipModel(*target.get()))
+							Messages::Add(message, Messages::Importance::High);
 					}
 				}
 			}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2795,9 +2795,10 @@ bool PlayerInfo::ShipModelIsKnown(const Ship& ship) const
 
 
 
-void PlayerInfo::DiscoverShipModel(const Ship& ship)
+// this func returns true iff the item was inserted
+bool PlayerInfo::DiscoverShipModel(const Ship& ship)
 {
-	knownShipModels.insert(ship.VariantName());
+	return knownShipModels.insert(ship.VariantName()).second;
 }
 
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -326,7 +326,7 @@ public:
 
 	// Methods for changing or getting if an ship model is known to the player.
 	bool ShipModelIsKnown(const Ship &ship) const;
-	void DiscoverShipModel(const Ship &ship);
+	bool DiscoverShipModel(const Ship &ship);
 
 private:
 	// Apply any "changes" saved in this player info to the global game state.


### PR DESCRIPTION
a but in previous commit was found where every time a ship was in range and scanned for model detection, the msg print would have been sent, this fix makes sure it prints only once.