### PR TITLE
Ship: fix regression from 5695b3ebd

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -644,7 +644,7 @@ void Ship::FinishLoading(bool isNewInstance)
 					merged.AddTurret(bit->GetPoint() * 2., bit->IsUnder(), outfit);
 					if(nextTurret != end)
 					{
-						if(nextGun->GetCustomSecIdx() != -1)
+						if(nextGun->GetOutfit() && (nextGun->GetCustomSecIdx() != -1))
 						{
 							for(const Hardpoint &hp : merged.Get())
 								if(nextGun->GetOutfit() == hp.GetOutfit())


### PR DESCRIPTION
when finishing loading torrents of a ship, don't set weapon as custom set if it doesn't have an outfit installed.

this fixes a crash on game loading