### PR TITLE
Ship: fix regression from d1afe2dff70b12e006bc8b50317ed4dbd998c0d2

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -644,14 +644,14 @@ void Ship::FinishLoading(bool isNewInstance)
 					merged.AddTurret(bit->GetPoint() * 2., bit->IsUnder(), outfit);
 					if(nextTurret != end)
 					{
-						if(nextGun->GetOutfit() && (nextGun->GetCustomSecIdx() != -1))
+						if(nextTurret->GetOutfit() && (nextTurret->GetCustomSecIdx() != -1))
 						{
 							for(const Hardpoint &hp : merged.Get())
-								if(nextGun->GetOutfit() == hp.GetOutfit())
+								if(nextTurret->GetOutfit() == hp.GetOutfit())
 								{
 									Hardpoint &weapon = const_cast<Hardpoint &>(hp);
 
-									weapon.SetCustomSecIdx(nextGun->GetCustomSecIdx());
+									weapon.SetCustomSecIdx(nextTurret->GetCustomSecIdx());
 								}
 						}
 						++nextTurret;


### PR DESCRIPTION
bad c&p resulted in using nextGun for the nextTurret loop.
this caused invalid custom secondary weapon set idx upon merge.
this commit fixes it