### PR TITLE
Ship: fix sec weapons set check on hp with no outfit

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4642,7 +4642,7 @@ const bool Ship::DefineAsCustomSecWeapon(const Outfit *selectedWeapon)
 	}
 
 	for(const Hardpoint &hp : Weapons())
-		if(hp.GetOutfit()->TrueName() == selectedWeapon->TrueName())
+		if(hp.GetOutfit() && (hp.GetOutfit()->TrueName() == selectedWeapon->TrueName()))
 		{
 			Hardpoint &weapon = const_cast<Hardpoint &>(hp);
 


### PR DESCRIPTION
fix a regression in the sec weapons set, as not all hps has outfits installed, this shoukd be taken into account when definging new sec weapons set